### PR TITLE
rid snapshot flags

### DIFF
--- a/federation.md
+++ b/federation.md
@@ -344,8 +344,6 @@ services:
       - --abci-host=0.0.0.0
       - --cometbft-rpc-port=26657
       - --cometbft-rpc-host=cometbft-consensus-node
-      - --sync.enable_state_sync
-      - --sync.enable_historical_sync
       - --block-fee-recipient-address=${BLOCK_FEE_RECIPIENT_ADDRESS}
     ports:
       - 8545:8545

--- a/rpc.md
+++ b/rpc.md
@@ -200,8 +200,7 @@ services:
       - --abci-host=0.0.0.0
       - --cometbft-rpc-port=26657
       - --cometbft-rpc-host=cometbft-consensus-node
-      - --sync.enable_state_sync
-      - --sync.enable_historical_sync
+
     ports:
       - 8545:8545
       - 8546:8546


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated node startup configuration to no longer explicitly enable state and historical synchronization for Reth-based services, aligning default behavior across federation and RPC deployments.

* **Documentation**
  * Refreshed deployment instructions to reflect the updated synchronization configuration and ensure consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->